### PR TITLE
docs: fix the alerts in markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,16 @@ This repo is used to document research performed by the Packit Team.
    category.
 1. Please create a new directory in the [research](research/) directory.
 1. Create an `index.md` document in that directory.
-   > **Note**
-   > In case you're working on a follow-up research, feel free to just add a new
-   > Markdown file next to already existing research.
 1. Make sure your `index.md` contains a clear description of what the outcome is
    from your research topic: ideally propose what the next steps should be.
    It's completely fine to tell that the technology is not interesting to us
    and there are no further actions.
 1. Add everything related to your topic in the directory.
 1. Open a pull request.
+
+> [!NOTE]
+> In case you're working on a follow-up research, feel free to just add a new
+> Markdown file next to already existing research.
 
 ### Template for research
 
@@ -42,7 +43,7 @@ authors: ‹Kerberos logins of authors, e.g. login or [login_a, login_b]›
 ## Next steps
 ```
 
-> **Warning**
+> [!WARNING]
 > Authors are not checked against the list of authors as with the blog posts,
 > keeping the authors in the attributes of research is just a courtesy to avoid
 > unnecessary _git blaming_.


### PR DESCRIPTION
GitHub has apparently changed syntax for no good reason…

Related to https://fosstodon.org/@FrostyX/112552088714938785